### PR TITLE
fix: fix mongodb data store flush process

### DIFF
--- a/app/dictrack/data_stores/mongodb.py
+++ b/app/dictrack/data_stores/mongodb.py
@@ -253,7 +253,7 @@ class MongoDBDataStore(BaseDataStore):
 
     def flush(self):
         try:
-            self._data_collection.drop()
+            self._data_collection.delete_many({})
         except Exception as e:
             logger.exception("Flush all data failed, {}".format(e.__repr__()))
 


### PR DESCRIPTION
Fix MongoDB data store flush process, using delete_many instead of drop.