### PR TITLE
fix: fix misuse of timedelta.seconds in time limiter

### DIFF
--- a/app/dictrack/limiters/time.py
+++ b/app/dictrack/limiters/time.py
@@ -76,7 +76,7 @@ class TimeLimiter(BaseLimiter):
             interval = timedelta(seconds=end_ts - start_ts)
         # Use interval
         else:
-            end_ts = start_ts + interval.seconds
+            end_ts = start_ts + interval.total_seconds()
 
         if start_ts == end_ts:
             raise ValueError(


### PR DESCRIPTION
Resolved an issue in the time limiter where timedelta.seconds was incorrectly used, leading to inaccurate calculations. Replaced timedelta.seconds with timedelta.total_seconds() to ensure proper handling of time durations.