### PR TITLE
Enhance redis compatibility

### DIFF
--- a/app/dictrack/data_caches/redis.py
+++ b/app/dictrack/data_caches/redis.py
@@ -152,7 +152,10 @@ class RedisDataCache(BaseDataCache):
             with client.pipeline() as pipe:
                 pipe.hset(self._get_data_key(tracker=tracker), tracker.name, b_tracker)
                 pipe.expire(self._get_data_key(tracker=tracker), self._data_expire)
-                pipe.zadd(self._get_last_cached_key(), {group_id: int(time.time())})
+                # Compatibility for redis-py 2.x series: Use execute_command instead of zadd
+                # redis-py 2.x does not support the newer zadd syntax introduced in 3.x,
+                # so execute_command is used to ensure compatibility across versions.
+                pipe.execute_command("ZADD", self._get_last_cached_key(), int(time.time()), group_id)
                 pipe.expire(self._get_last_cached_key(), self._data_expire)
                 pipe.execute()
 

--- a/build/docker/requirements_py2.txt
+++ b/build/docker/requirements_py2.txt
@@ -4,8 +4,9 @@ dictor==0.1.12
 flask==1.1.4
 gevent==22.10.2
 gunicorn==19.10.0
+hiredis==1.1.0
 pymongo==3.13.0
 python-redis-lock==3.7.0
-redis[hiredis]==3.5.3
+redis>=2.10.0,<=3.5.3
 six==1.16.0
 sortedcontainers==2.4.0

--- a/setup.py
+++ b/setup.py
@@ -41,31 +41,31 @@ setup(
     packages=find_packages(where="app"),
     package_dir={"": "app"},
     install_requires=[
-        "dictor >= 0.1.12, < 1.0",
-        "six >= 1.16.0, < 2.0",
+        "dictor < 1.0",
+        "six < 2.0",
         "tzlocal == 2.1;python_version == '2.7'",
         "apscheduler == 3.8.1;python_version == '2.7'",
-        "apscheduler >= 3.10.4, < 4.0;python_version >= '3.7'",
+        "apscheduler < 4.0;python_version >= '3.7'",
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*",
     extras_require={
         "redis": [
             "python-redis-lock == 3.7.0;python_version == '2.7'",
-            "python-redis-lock >= 4.0.0, < 5.0;python_version >= '3.7'",
+            "python-redis-lock < 5.0;python_version >= '3.7'",
             "hiredis == 1.1.0;python_version == '2.7'",
-            "redis == 3.5.3;python_version == '2.7'",
-            "redis[hiredis] >= 5.1.1, < 6.0;python_version >= '3.7'",
+            "redis >= 2.10.0, <= 3.5.3;python_version == '2.7'",
+            "redis[hiredis] < 6.0;python_version >= '3.7'",
         ],
         "memory": [
-            "sortedcontainers >= 2.4.0, < 3.0",
+            "sortedcontainers < 3.0",
         ],
         "mongodb": [
             "pymongo == 3.13.0;python_version == '2.7'",
-            "pymongo >= 3.0, < 5.0;python_version >= '3.7'",
+            "pymongo < 5.0;python_version >= '3.7'",
         ],
         "gevent": [
             "apscheduler[gevent] == 3.8.1;python_version == '2.7'",
-            "apscheduler[gevent] >= 3.10.4, < 4.0;python_version >= '3.7'",
+            "apscheduler[gevent] < 4.0;python_version >= '3.7'",
         ],
     },
 )


### PR DESCRIPTION
- Improved compatibility for ZADD command to handle syntax differences between redis-py 2.x and 3.x+ versions, ensuring support for redis-py 2.10.0+ while maintaining functionality in newer versions.
- Modify setup.py and requirements_py2.txt for supporting redis-py 2.10.0+.

BREAKING CHANGE:
- redis-py now support 2.10.0+.