### PR TITLE
fix: fix misuse of timedelta.seconds in time limiter

### DIFF
--- a/app/dictrack/limiters/time.py
+++ b/app/dictrack/limiters/time.py
@@ -122,7 +122,7 @@ class TimeLimiter(BaseLimiter):
 
         now_ts = int(time.time()) if "now_ts" not in kwargs else kwargs["now_ts"]
         delta_seconds = (
-            self.interval.seconds
+            self.interval.total_seconds()
             if "reset_seconds" not in kwargs
             else kwargs["reset_seconds"]
         )

--- a/app/tests/test_limiters.py
+++ b/app/tests/test_limiters.py
@@ -82,6 +82,17 @@ def test_time():
     assert limiter.limited is True
 
     limiter.reset()
+    limiter.pre_track({}, MockTracker())
+    assert limiter.limited is False
+
+    now_ts = int(time.time())
+    limiter = TimeLimiter(start_ts=now_ts - 86400 * 5, interval=timedelta(days=1))
+    limiter.pre_track({}, MockTracker())
+    assert limiter.limited is True
+
+    limiter.reset()
+    time.sleep(1)
+    limiter.pre_track({}, MockTracker())
     assert limiter.limited is False
 
     limiter = TimeLimiter(start_ts=int(time.time()) + 2, interval=timedelta(seconds=1))


### PR DESCRIPTION
Resolved an issue in the time limiter where timedelta.seconds was incorrectly used, leading to inaccurate calculations. Replaced timedelta.seconds with timedelta.total_seconds() to ensure proper handling of time durations.
Added unit test code for the issue.