### PR TITLE
fix: stale data check failure in Python 3

### DIFF
--- a/app/dictrack/data_caches/redis.py
+++ b/app/dictrack/data_caches/redis.py
@@ -412,6 +412,9 @@ class RedisDataCache(BaseDataCache):
         for group_id in client.zrangebyscore(
             self._get_last_cached_key(), 0, now_ts - self.stale_threshold
         ):
+            # Python 3 compatibility, decode bytes to string
+            if six.PY3:
+                group_id = group_id.decode("utf-8")
             self.data_store.store_all(group_id, self.fetch(group_id))
             self.remove(group_id)
         else:

--- a/app/dictrack/data_stores/mongodb.py
+++ b/app/dictrack/data_stores/mongodb.py
@@ -149,6 +149,9 @@ class MongoDBDataStore(BaseDataStore):
         valid_type(expire, six.integer_types, allow_empty=True)
         valid_type(expire_at, six.integer_types, allow_empty=True)
 
+        if not trackers:
+            return True
+
         now_ts = int(time.time())
         common_update = {"$setOnInsert": {}}
         # Process expire timestamp


### PR DESCRIPTION
Fix an issue in `RedisDataCache` where stale data checks failed in Python 3. This was caused by Redis returning values as `bytes` instead of `str`, which led to incorrect data key generation.