### PR TITLE
Improve reset flow

### DIFF
--- a/app/dictrack/limiters/count.py
+++ b/app/dictrack/limiters/count.py
@@ -57,10 +57,14 @@ class CountLimiter(BaseLimiter):
             self.limited = True
 
             return False
+        else:
+            self.limited = False
 
-        return True
+            return True
 
     def reset(self, *args, **kwargs):
         super(CountLimiter, self).reset()
 
-        self.remaining = self.count
+        count = kwargs["reset_count"] if "reset_count" in kwargs else self.count
+
+        self.count = self.remaining = count

--- a/app/dictrack/limiters/time.py
+++ b/app/dictrack/limiters/time.py
@@ -114,8 +114,10 @@ class TimeLimiter(BaseLimiter):
             self.limited = True
 
             return False
+        else:
+            self.limited = False
 
-        return True
+            return True
 
     def reset(self, *args, **kwargs):
         super(TimeLimiter, self).reset()

--- a/app/dictrack/manager.py
+++ b/app/dictrack/manager.py
@@ -243,7 +243,7 @@ class TrackingManager(object):
         self.data_store.remove(group_id, name=name)
 
     @typecheck()
-    def reset_tracker(self, group_id, name, reset_policy=None):
+    def reset_tracker(self, group_id, name, reset_policy=None, *args, **kwargs):
         """
         Reset a tracker in a specified group according to the provided reset policy.
 
@@ -282,7 +282,7 @@ class TrackingManager(object):
             return False
 
         tracker.forward_event(self._dispatch_event)
-        tracker.reset(reset_policy=reset_policy)
+        tracker.reset(reset_policy=reset_policy, *args, **kwargs)
         self.update_tracker(group_id, tracker)
 
         return True

--- a/app/dictrack/trackers/base.py
+++ b/app/dictrack/trackers/base.py
@@ -68,7 +68,7 @@ class BaseTracker(six.with_metaclass(ABCMeta)):
         loop_forever=False,
         init_progress=0,
         *args,
-        **kwargs
+        **kwargs,
     ):
         """
         A base class for tracking data and maintaining progress based on conditions, limiters, and targets.
@@ -364,7 +364,7 @@ class BaseTracker(six.with_metaclass(ABCMeta)):
         for code in EVENT_ALL:
             self.add_listener(code, cb)
 
-    def reset(self, reset_policy=None):
+    def reset(self, reset_policy=None, *args, **kwargs):
         valid_obj(
             reset_policy, list(six.moves.range(ResetPolicy.ALL + 1)), allow_empty=True
         )
@@ -377,7 +377,7 @@ class BaseTracker(six.with_metaclass(ABCMeta)):
             self._progress = 0
         if ResetPolicy.LIMITER & reset_policy:
             for limiter in self.limiters:
-                limiter.reset()
+                limiter.reset(*args, **kwargs)
 
             self._limited = False
 

--- a/app/tests/test_limiters.py
+++ b/app/tests/test_limiters.py
@@ -34,6 +34,12 @@ def test_count():
     with pytest.raises(TypeError):
         CountLimiter("3")
 
+    limiter.reset(reset_count=5)
+    assert limiter.count == 5
+    for _ in six.moves.range(5):
+        limiter.post_track({}, post_tracker)
+    assert limiter.limited is True
+
     limiter = CountLimiter(1)
     post_tracker = MockTracker()
     post_tracker.completed = True

--- a/app/tests/test_limiters.py
+++ b/app/tests/test_limiters.py
@@ -95,6 +95,19 @@ def test_time():
     limiter.pre_track({}, MockTracker())
     assert limiter.limited is False
 
+    now_ts = int(time.time())
+    limiter.reset(now_ts=now_ts - 3600 * 12)
+    limiter.pre_track({}, MockTracker())
+    assert limiter.limited is False
+
+    now_ts = int(time.time())
+    limiter.reset(now_ts=now_ts + 2, reset_seconds=10)
+    limiter.pre_track({}, MockTracker())
+    assert limiter.limited is True
+    time.sleep(3)
+    limiter.pre_track({}, MockTracker())
+    assert limiter.limited is False
+
     limiter = TimeLimiter(start_ts=int(time.time()) + 2, interval=timedelta(seconds=1))
     limiter.pre_track({}, MockTracker())
     assert limiter.limited is True


### PR DESCRIPTION
This pull request introduces enhancements to the reset functionality across multiple components of the `dictrack` module, ensuring more flexibility and configurability. Additionally, it updates the test suite to validate the new behavior. The most important changes include adding support for passing additional arguments to reset methods, modifying limiter behavior, and extending test coverage.

### Enhancements to reset functionality:

* [`app/dictrack/limiters/count.py`](diffhunk://#diff-7b02ee0fd0e63cc2b549c224f6bcf50501a0174572d24a18d4ad5f9a72f9de7cR60-R70): Updated the `reset` method in `CountLimiter` to accept an optional `reset_count` parameter, allowing the limiter's count to be dynamically reset.
* [`app/dictrack/trackers/base.py`](diffhunk://#diff-9431c0a1e9aac6d970df69419d1378cbfe02257a53f594de9d75c08d76cf8533L367-R367): Modified the `reset` method in the base tracker to accept additional `*args` and `**kwargs`, propagating them to limiter resets for greater flexibility. [[1]](diffhunk://#diff-9431c0a1e9aac6d970df69419d1378cbfe02257a53f594de9d75c08d76cf8533L367-R367) [[2]](diffhunk://#diff-9431c0a1e9aac6d970df69419d1378cbfe02257a53f594de9d75c08d76cf8533L380-R380)
* [`app/dictrack/manager.py`](diffhunk://#diff-7b0437b8569c2d0395b1c5bf83edbf3747b0d7989aa9cbd2a1226e096eed1e20L246-R246): Updated the `reset_tracker` method to accept and pass additional arguments to the underlying tracker reset methods. [[1]](diffhunk://#diff-7b0437b8569c2d0395b1c5bf83edbf3747b0d7989aa9cbd2a1226e096eed1e20L246-R246) [[2]](diffhunk://#diff-7b0437b8569c2d0395b1c5bf83edbf3747b0d7989aa9cbd2a1226e096eed1e20L285-R285)

### Improvements to limiter behavior:

* `app/dictrack/limiters/count.py` and `app/dictrack/limiters/time.py`: Added logic to explicitly set `self.limited` to `False` when conditions are met, ensuring accurate limiter state tracking. [[1]](diffhunk://#diff-7b02ee0fd0e63cc2b549c224f6bcf50501a0174572d24a18d4ad5f9a72f9de7cR60-R70) [[2]](diffhunk://#diff-d4dc33afe8ec1b5c8b23e7261191a29b20661ef3bffb9464698342a3320cde58R117-R118)

### Test coverage extensions:

* [`app/tests/test_limiters.py`](diffhunk://#diff-f530e5bca9e759b0c2afa6a49f5356f44014b665ea603758110bcfbf60fe6e18R37-R42): Enhanced tests for `CountLimiter` and `TimeLimiter` to validate the new reset behavior with additional parameters (`reset_count`, `reset_seconds`, etc.) and ensure correct limiter state transitions. [[1]](diffhunk://#diff-f530e5bca9e759b0c2afa6a49f5356f44014b665ea603758110bcfbf60fe6e18R37-R42) [[2]](diffhunk://#diff-f530e5bca9e759b0c2afa6a49f5356f44014b665ea603758110bcfbf60fe6e18R104-R116)