### PR TITLE
fix: correct reset logic and parameter handling

### DIFF
--- a/app/dictrack/manager.py
+++ b/app/dictrack/manager.py
@@ -275,12 +275,15 @@ class TrackingManager(object):
         Dispatches reset events through the tracker's `forward_event` method and updates the tracker after reset.
         """
         valid_type(name, six.string_types)
-        valid_obj(reset_policy, list(six.moves.range(ResetPolicy.ALL + 1)))
+        valid_obj(
+            reset_policy, list(six.moves.range(ResetPolicy.ALL + 1)), allow_empty=True
+        )
 
-        tracker = self.get_tracker(group_id, name)
-        if tracker is None:
+        trackers = self.get_trackers(group_id, name)
+        if not trackers:
             return False
 
+        tracker = trackers[0]
         tracker.forward_event(self._dispatch_event)
         tracker.reset(reset_policy=reset_policy, *args, **kwargs)
         self.update_tracker(group_id, tracker)


### PR DESCRIPTION
This pull request updates the `reset_tracker` method in `app/dictrack/manager.py` to improve its handling of reset policies and multiple trackers. The most important changes include allowing empty reset policies and modifying the logic to handle multiple trackers.

### Improvements to reset policy handling:
* Updated the `valid_obj` call to allow empty reset policies by adding the `allow_empty=True` argument.

### Enhancements to tracker management:
* Replaced the retrieval of a single tracker (`get_tracker`) with the retrieval of multiple trackers (`get_trackers`) and updated the logic to handle cases where no trackers are found.