### PR TITLE
perf: enhance `CountLimiter` `__repr__` output

### DIFF
--- a/app/dictrack/limiters/count.py
+++ b/app/dictrack/limiters/count.py
@@ -48,7 +48,7 @@ class CountLimiter(BaseLimiter):
         return hash(self.count)
 
     def __repr__(self):
-        return "<CountLimiter (count={})>".format(self.count)
+        return "<CountLimiter (count={} remaining={})>".format(self.count, self.remaining)
 
     def post_track(self, data, post_tracker, *args, **kwargs):
         self.remaining -= 1


### PR DESCRIPTION
This pull request introduces a small change to the `__repr__` method of the `CountLimiter` class in `app/dictrack/limiters/count.py`. The updated method now includes the `remaining` attribute in its string representation, providing more detailed information about the limiter's state.