### PR TITLE
fix: python 2 syntax issue

### DIFF
--- a/app/dictrack/limiters/count.py
+++ b/app/dictrack/limiters/count.py
@@ -48,7 +48,9 @@ class CountLimiter(BaseLimiter):
         return hash(self.count)
 
     def __repr__(self):
-        return "<CountLimiter (count={} remaining={})>".format(self.count, self.remaining)
+        return "<CountLimiter (count={} remaining={})>".format(
+            self.count, self.remaining
+        )
 
     def post_track(self, data, post_tracker, *args, **kwargs):
         self.remaining -= 1

--- a/app/dictrack/trackers/base.py
+++ b/app/dictrack/trackers/base.py
@@ -68,7 +68,7 @@ class BaseTracker(six.with_metaclass(ABCMeta)):
         loop_forever=False,
         init_progress=0,
         *args,
-        **kwargs,
+        **kwargs
     ):
         """
         A base class for tracking data and maintaining progress based on conditions, limiters, and targets.


### PR DESCRIPTION
This pull request includes minor formatting changes to improve code readability in `CountLimiter` and `BaseTracker` classes.

Formatting improvements:

* [`app/dictrack/limiters/count.py`](diffhunk://#diff-7b02ee0fd0e63cc2b549c224f6bcf50501a0174572d24a18d4ad5f9a72f9de7cL51-R53): Reformatted the `__repr__` method to improve readability by splitting the string formatting across multiple lines.
* [`app/dictrack/trackers/base.py`](diffhunk://#diff-9431c0a1e9aac6d970df69419d1378cbfe02257a53f594de9d75c08d76cf8533L71-R71): Removed an unnecessary trailing comma in the `__init__` method definition for cleaner syntax.