### PR TITLE
feat: validate count limits and improve reset logic for limiters

### DIFF
--- a/app/dictrack/limiters/count.py
+++ b/app/dictrack/limiters/count.py
@@ -68,5 +68,14 @@ class CountLimiter(BaseLimiter):
         super(CountLimiter, self).reset()
 
         count = kwargs.get("reset_count", self.count)
+        if count < 0:
+            raise ValueError("`reset_count` must be a positive integer or zero")
 
         self.count = self.remaining = count
+
+        if count == 0:
+            self.limited = True
+
+            return False
+
+        return True

--- a/app/dictrack/limiters/time.py
+++ b/app/dictrack/limiters/time.py
@@ -132,3 +132,5 @@ class TimeLimiter(BaseLimiter):
         self.interval = timedelta(seconds=delta_seconds)
         self.start = now_ts
         self.end = now_ts + delta_seconds
+
+        return self.pre_track(None, None)

--- a/app/dictrack/trackers/base.py
+++ b/app/dictrack/trackers/base.py
@@ -376,10 +376,9 @@ class BaseTracker(six.with_metaclass(ABCMeta)):
         if ResetPolicy.PROGRESS & reset_policy:
             self._progress = 0
         if ResetPolicy.LIMITER & reset_policy:
-            for limiter in self.limiters:
-                limiter.reset(*args, **kwargs)
-
-            self._limited = False
+            self._limited = any(
+                not limiter.reset(*args, **kwargs) for limiter in self.limiters
+            )
 
         self._completed = False
 

--- a/app/tests/test_limiters.py
+++ b/app/tests/test_limiters.py
@@ -27,18 +27,25 @@ def test_count():
         limiter.post_track({}, post_tracker)
     assert limiter.limited is True
 
-    limiter.reset()
+    assert limiter.reset() is True
     assert limiter.count == 3
     assert limiter.limited is False
 
     with pytest.raises(TypeError):
         CountLimiter("3")
 
-    limiter.reset(reset_count=5)
+    assert limiter.reset(reset_count=5) is True
     assert limiter.count == 5
     for _ in six.moves.range(5):
         limiter.post_track({}, post_tracker)
     assert limiter.limited is True
+
+    assert limiter.reset(reset_count=0) is False
+    assert limiter.count == limiter.remaining == 0
+    assert limiter.limited is True
+
+    with pytest.raises(ValueError):
+        limiter.reset(reset_count=-1)
 
     limiter = CountLimiter(1)
     post_tracker = MockTracker()
@@ -87,7 +94,7 @@ def test_time():
     limiter.pre_track({}, MockTracker())
     assert limiter.limited is True
 
-    limiter.reset()
+    assert limiter.reset() is True
     limiter.pre_track({}, MockTracker())
     assert limiter.limited is False
 
@@ -96,18 +103,18 @@ def test_time():
     limiter.pre_track({}, MockTracker())
     assert limiter.limited is True
 
-    limiter.reset()
+    assert limiter.reset() is True
     time.sleep(1)
     limiter.pre_track({}, MockTracker())
     assert limiter.limited is False
 
     now_ts = int(time.time())
-    limiter.reset(now_ts=now_ts - 3600 * 12)
+    assert limiter.reset(now_ts=now_ts - 3600 * 12) is True
     limiter.pre_track({}, MockTracker())
     assert limiter.limited is False
 
     now_ts = int(time.time())
-    limiter.reset(now_ts=now_ts + 2, reset_seconds=10)
+    assert limiter.reset(now_ts=now_ts + 2, reset_seconds=10) is False
     limiter.pre_track({}, MockTracker())
     assert limiter.limited is True
     time.sleep(3)


### PR DESCRIPTION
This pull request refines the behavior of the `reset` method across multiple limiter classes and their corresponding tests. The changes ensure consistent return values, stricter validation, and improved tracking of limiter states. Additionally, the test cases have been updated to verify the new functionality.

### Enhancements to `reset` method behavior:

* **`CountLimiter` (`app/dictrack/limiters/count.py`)**:
  - Added validation to ensure `reset_count` is a non-negative integer, raising a `ValueError` if violated.
  - Updated the method to return `False` when `reset_count` is `0`, marking the limiter as limited. Otherwise, it returns `True`.

* **`TimeLimiter` (`app/dictrack/limiters/time.py`)**:
  - Modified `reset` to return the result of `pre_track`, ensuring the limiter's state is updated appropriately.

* **`BaseTracker` (`app/dictrack/trackers/base.py`)**:
  - Adjusted `reset` to set `_limited` based on the return values of associated limiters' `reset` methods, using `any()` for consistency.

### Updates to test cases:

* **`test_count` (`app/tests/test_limiters.py`)**:
  - Enhanced test cases to assert the return values of `reset`.
  - Added tests for edge cases, such as `reset_count=0` and invalid `reset_count` values (e.g., negative integers).

* **`test_time` (`app/tests/test_limiters.py`)**:
  - Updated test cases to validate the return values of `reset` and ensure the limiter's state transitions are correctly handled. [[1]](diffhunk://#diff-f530e5bca9e759b0c2afa6a49f5356f44014b665ea603758110bcfbf60fe6e18L90-R97) [[2]](diffhunk://#diff-f530e5bca9e759b0c2afa6a49f5356f44014b665ea603758110bcfbf60fe6e18L99-R117)