### PR TITLE
feat: filter out None values during tracker deserialization process

### DIFF
--- a/app/dictrack/data_caches/redis.py
+++ b/app/dictrack/data_caches/redis.py
@@ -194,7 +194,12 @@ class RedisDataCache(BaseDataCache):
             if b_tracker is None:
                 return []
 
-            return [BaseTracker.deserialize(b_tracker)]
+            tracker = BaseTracker.deserialize(b_tracker)
+            # Filter out None value
+            if tracker is None:
+                return []
+
+            return tracker
         # All data
         elif name is None:
             b_trackers = [
@@ -296,6 +301,10 @@ class RedisDataCache(BaseDataCache):
                     self._get_data_key(group_id=group_id), count=self._batch_size
                 ):
                     tracker = BaseTracker.deserialize(b_tracker)
+                    # Skip process if tracker is None
+                    if tracker is None:
+                        continue
+
                     tracker.forward_event(self.forward_cb)
                     tracker.track(data, cache=conditions_cache, *args, **kwargs)
 

--- a/app/dictrack/data_stores/mongodb.py
+++ b/app/dictrack/data_stores/mongodb.py
@@ -214,9 +214,13 @@ class MongoDBDataStore(BaseDataStore):
 
             return False, []
 
-        return True, [
+        trackers = [
             BaseTracker.deserialize(document["b_tracker"]) for document in cursor
         ]
+        # Filter out None values
+        trackers = [tracker for tracker in trackers if tracker is not None]
+
+        return True, trackers
 
     @typecheck()
     def remove(self, group_id, name=None, **kwargs):
@@ -249,6 +253,12 @@ class MongoDBDataStore(BaseDataStore):
 
             return False, []
 
+        # Filter out None values
+        removed_trackers = [
+            removed_tracker
+            for removed_tracker in removed_trackers
+            if removed_tracker is not None
+        ]
         for tracker in removed_trackers:
             tracker.removed = True
 
@@ -291,6 +301,12 @@ class MongoDBDataStore(BaseDataStore):
         except Exception as e:
             logger.exception("Remove expired tracker failed, {}".format(e.__repr__()))
 
+        # Filter out None values
+        removed_trackers = [
+            removed_tracker
+            for removed_tracker in removed_trackers
+            if removed_tracker is not None
+        ]
         # Mark removed and check cache
         for tracker in removed_trackers:
             self.data_cache.remove(tracker.group_id, tracker.name)


### PR DESCRIPTION
This pull request improves the robustness of tracker deserialization and processing by handling cases where deserialization might fail and ensuring that `None` values are filtered out of operations. The changes span multiple files and functions, focusing on error handling and data integrity.

### Enhancements to Deserialization:

* `app/dictrack/trackers/base.py`:
  - Updated `deserialize` to handle `AttributeError` (e.g., missing class definitions) and other exceptions, logging warnings or errors and returning `None` when deserialization fails.
  - Updated `deserialize_list` to filter out `None` values from the list of deserialized trackers.

### Filtering `None` Values in Data Handling:

* `app/dictrack/data_caches/redis.py`:
  - Modified `fetch` to return an empty list if deserialization results in `None`.
  - Updated `track` to skip processing if a deserialized tracker is `None`.

* `app/dictrack/data_stores/mongodb.py`:
  - Updated `load` to filter out `None` values from the list of deserialized trackers.
  - Modified `remove` to filter out `None` values from the list of removed trackers before marking them as removed.
  - Enhanced `_check_expire` to filter out `None` values from the list of expired trackers before processing them.