### PR TITLE
fix: Return tracker as a single-item list for consistency

### DIFF
--- a/app/dictrack/data_caches/redis.py
+++ b/app/dictrack/data_caches/redis.py
@@ -199,7 +199,7 @@ class RedisDataCache(BaseDataCache):
             if tracker is None:
                 return []
 
-            return tracker
+            return [tracker]
         # All data
         elif name is None:
             b_trackers = [


### PR DESCRIPTION
This pull request includes a small change to the `fetch` method in `app/dictrack/data_caches/redis.py`. The method now always returns a list, even when a single tracker is found, to ensure consistent return types.