### PR TITLE
chore: Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+# Install Python 2.7 and Python 3
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    python2 \
+    python2-dev \
+    python3 \
+    python3-dev \
+    python3-pip \
+    curl \
+    build-essential \
+    libffi-dev \
+    git \
+    sudo
+
+# Install pip for Python 2.7
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \
+    && python2 get-pip.py \
+    && rm get-pip.py
+
+# Install common Python tools
+RUN python3 -m pip install --upgrade pip setuptools wheel tox virtualenv
+RUN python2 -m pip install --upgrade pip setuptools wheel virtualenv
+
+# Clean up
+RUN apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
 
 # Install Python 2.7 and Python 3
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "name": "dictrack",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
+    "workspaceFolder": "/workspaces/dictrack",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python"
+            ]
+        }
+    },
+    "postCreateCommand": "python3 -m pip install -e .[redis,mongo,memory,gevent] && python2 -m pip install -e .[redis,mongo,memory,gevent] && python3 -m pip install pytest tox && python2 -m pip install pytest tox"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspaces/dictrack:cached
+    command: /bin/sh -c "while sleep 1000; do :; done"
+    environment:
+      - REDIS_HOST=redis
+      - MONGODB_HOST=mongodb
+      - PYTHONPATH=/workspaces/dictrack/app
+    links:
+      - redis
+      - mongodb
+    depends_on:
+      - redis
+      - mongodb
+
+  redis:
+    image: redis:6.2
+    # ports:
+    #   - "6379:6379"
+
+  mongodb:
+    image: mongo:5.0
+    # ports:
+    #   - "27017:27017"


### PR DESCRIPTION
This PR adds .devcontainer configuration for VS Code and Codespaces.

p.s. Now, devcontainer supoprted `python2.7` and `python3.8` in dev environment.